### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/assets/stylesheets/buyers.scss
+++ b/app/assets/stylesheets/buyers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the buyers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -1,0 +1,2 @@
+class BuyersController < ApplicationController
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index]
 
   def index
-    @items = Item.all.order(id: "ASC")
+    @items = Item.all.order(id: "DESC")
     @buyer = Buyer.new
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index]
 
   def index
-    @items = Item.all
+    @items = Item.all.order(id: "ASC")
     @buyer = Buyer.new
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all
+    @buyer = Buyer.new
   end
 
   def new

--- a/app/helpers/buyers_helper.rb
+++ b/app/helpers/buyers_helper.rb
@@ -1,0 +1,2 @@
+module BuyersHelper
+end

--- a/app/models/buyer.rb
+++ b/app/models/buyer.rb
@@ -1,0 +1,4 @@
+class Buyer < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,12 +10,12 @@ class Item < ApplicationRecord
   belongs_to_active_hash :delivery_area
   belongs_to_active_hash :delivery_date
   with_options presence: true do
-      validates :image, :name, :text, :price, :category, :status, :shipping_charge, :delivery_area, :delivery_date, :user
-    end
+    validates :image, :name, :text, :price, :category, :status, :shipping_charge, :delivery_area, :delivery_date, :user
+  end
 
   with_options numericality: { other_than: 1 } do
-      validates :category_id, :status_id, :shipping_charge_id, :delivery_area_id, :delivery_date_id
-    end
+    validates :category_id, :status_id, :shipping_charge_id, :delivery_area_id, :delivery_date_id
+  end
   validates :price, numericality: { greater_than_or_equal_to: 300 }
   validates :price, numericality: { less_than_or_equal_to: 9_999_999 }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,53 +125,51 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
-          <% if item.buyer != nil%>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
+            <% if item.buyer != nil%>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <% end %>
           </div>
-          <% end %>
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
       <% end %>
       <%# 商品がない場合のダミー %>
       <% if @items == nil %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  商品を出品してね！
+                </h3>
+                <div class='item-price'>
+                  <span>99999999円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+        </li>
       <% end %>
       <%# //商品がない場合のダミー %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,37 +128,32 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to "#" do %>
-            <div class='item-img-content'>
-             <%= image_tag item.image, class:"item-img" %>
-
-            <%# 商品が売れていればsold outの表示 %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-            <%# //商品が売れていればsold outの表示 %>
-
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br>(税込み)</span>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
-                </div>
-              </div>
-            </div>
+      <li class='list'>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag item.image, class: "item-img" %>
+          <% if item.buyer != nil%>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
           <% end %>
-        </li>
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= item.name %>
+          </h3>
+          <div class='item-price'>
+            <span><%= item.price %>円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% if @items == nil %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -176,9 +171,8 @@
           </div>
         </div>
         <% end %>
-      <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# //商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,32 +127,34 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class='item-img-content'>
+             <%= image_tag item.image, class:"item-img" %>
 
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outの表示 %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            <%# 商品が売れていればsold outの表示 %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+            <%# //商品が売れていればsold outの表示 %>
+
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -159,6 +159,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items == nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -175,6 +176,7 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合のダミー %>

--- a/db/migrate/20200814054748_create_buyers.rb
+++ b/db/migrate/20200814054748_create_buyers.rb
@@ -1,0 +1,9 @@
+class CreateBuyers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :buyers do |t|
+      t.references :user,         null: false, foreign_key: true
+      t.references :item,         null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_003659) do
+ActiveRecord::Schema.define(version: 2020_08_14_054748) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2020_08_10_003659) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "buyers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_buyers_on_item_id"
+    t.index ["user_id"], name: "index_buyers_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +76,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_003659) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "buyers", "items"
+  add_foreign_key "buyers", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/buyers.rb
+++ b/spec/factories/buyers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :buyer do
+    
+  end
+end

--- a/spec/helpers/buyers_helper_spec.rb
+++ b/spec/helpers/buyers_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the BuyersHelper. For example:
+#
+# describe BuyersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe BuyersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/buyer_spec.rb
+++ b/spec/models/buyer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Buyer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/buyers_request_spec.rb
+++ b/spec/requests/buyers_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Buyers", type: :request do
+
+end


### PR DESCRIPTION
# What
- ユーザーが出品した商品を「画像、価格、商品名」が表示されるように実装。
- 売却済みの商品については「soldout」が表示されるように変更。
- ログアウト状態でも商品一覧を閲覧可能に実装。

# Why
- トップページで商品一覧を閲覧できるようにするため。
--------------------
お疲れ様です。
プルリクエストを送付いたしますので、レビューのほどよろしくお願いします。